### PR TITLE
fix: `no-regexp-s-flag` crash on non-string flags

### DIFF
--- a/lib/rules/no-regexp-s-flag.js
+++ b/lib/rules/no-regexp-s-flag.js
@@ -5,7 +5,21 @@ module.exports = (context, badBrowser) => ({
     }
   },
   'CallExpression[callee.name="RegExp"], NewExpression[callee.name="RegExp"]'(node) {
-    if (node.arguments[1] && node.arguments[1].value.includes('s')) {
+    const [, flags] = node.arguments;
+    if (
+      flags && 
+      (
+        (
+          flags.type === 'Literal' &&
+          typeof flags.value === 'string' &&
+          flags.value.includes('s')
+        ) || 
+        (
+          flags.type === 'TemplateLiteral' &&
+          flags.quasis.some(({value: {raw}}) => raw.includes('s'))
+        )
+      )
+    ) {
       context.report(node, `RegExp "s" flag is not supported in ${badBrowser}`)
     }
   }

--- a/test/no-regexp-s-flag.js
+++ b/test/no-regexp-s-flag.js
@@ -8,6 +8,7 @@ ruleTester.run('no-regexp-s-flag', rule, {
     {code: '/foo.bar/'},
     {code: '/foo.bar/g'},
     {code: 'new RegExp("foo.bar")'},
+    {code: 'new RegExp("foo.bar", flags)'},
     {code: 'new RegExp("foo.bar", "u")'},
     {code: 'new RegExp("foo.bar", "g")'},
     {code: 'RegExp("foo.bar", "g")'},
@@ -23,6 +24,14 @@ ruleTester.run('no-regexp-s-flag', rule, {
     },
     {
       code: 'new RegExp("foo.bar", "s")',
+      errors: [
+        {
+          message: 'RegExp "s" flag is not supported in undefined'
+        }
+      ]
+    },
+    {
+      code: 'new RegExp("foo.bar", `s`)',
       errors: [
         {
           message: 'RegExp "s" flag is not supported in undefined'


### PR DESCRIPTION
Second argument type is not checked. Cause eslint crash on `Identifier`

Only allow `Literal` and `TemplateLiteral`, 

`TemplateLiteral` should not very offen to see, but not very hard to add this check, so I added it.