### PR TITLE
fix: update no-regexp-lookbehind rule to reflect Safari support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ that matches your `tsconfig.json` `target` value.
 
 `eslint-plugin-escompat` uses the `browserslist` configuration in `package.json`
 
-If you have a browserlist, is is safe to enable all of these rules - as any that
+If you have a browserslist, is is safe to enable all of these rules - as any that
 do not coincide with your chosen browsers will be turned off automatically.
 
 See [browserslist/browserslist](https://github.com/browserslist/browserslist)

--- a/docs/no-bind-operator.md
+++ b/docs/no-bind-operator.md
@@ -35,7 +35,7 @@ If you're using the bind operator as a call expression, then you can use the `.c
 ```js
 // these are equivalent:
 obj::func(val)
-func.call(obj, vall)
+func.call(obj, val)
 
 // these are equivalent:
 ::obj.func(val)

--- a/docs/no-exponentiation-operator.md
+++ b/docs/no-exponentiation-operator.md
@@ -1,6 +1,6 @@
 # no-exponentiation-operator
 
-This prevents use of the ES2017 Expontentiation Operator:
+This prevents use of the ES2017 Exponentiation Operator:
 
 ```js
 2 ** 3 === 8

--- a/docs/no-regexp-lookbehind.md
+++ b/docs/no-regexp-lookbehind.md
@@ -17,4 +17,4 @@ These will not be allowed because they are not supported in the following browse
 
 ## What is the Fix?
 
-You may be able to rewrite your experession using (Negative) Lookaheads, but if not then there is no solution for this, aside from pulling in a custom RegExp library.
+You may be able to rewrite your expression using (Negative) Lookaheads, but if not then there is no solution for this, aside from pulling in a custom RegExp library.

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ createRule(
 );
 createRule(
   "no-regexp-lookbehind",
-  "edge < 79, safari > 0, firefox < 78, chrome < 62",
+  "edge < 79, safari < 16.4, firefox < 78, chrome < 62",
   "disallow the use of RegExp lookbehinds"
 );
 createRule(
@@ -122,7 +122,7 @@ createRule(
 createRule(
   "no-optional-chaining",
   "edge < 80, safari < 13.1, firefox < 72, chrome < 80",
-  "disallow the .? optional chaning operator",
+  "disallow the .? optional chaining operator",
   { ts: 2020 }
 );
 createRule(
@@ -141,7 +141,7 @@ createRule(
 createRule(
   "no-numeric-separators",
   "edge < 79, safari < 13, firefox < 68, chrome < 75",
-  "disallow use of numeric seperators like 1_000_000",
+  "disallow use of numeric separators like 1_000_000",
   { ts: 2021 }
 );
 


### PR DESCRIPTION
Safari supports lookbehind assertions starting from version 16.4. Also fixed a couple of typos in some of the rule descriptions and documentation.

Resolves: https://github.com/keithamus/eslint-plugin-escompat/issues/20