### PR TITLE
feat: ES2022 `no-top-level-await`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ for configuration. Here's some examples:
 - [no-regexp-lookbehind](./docs/no-regexp-lookbehind.md)
 - [no-regexp-named-group](./docs/no-regexp-named-group.md)
 - [no-regexp-s-flag](./docs/no-regexp-s-flag.md)
+- [no-top-level-await](./docs/no-top-level-await.md)
 
 ## Inspiration
 

--- a/docs/no-top-level-await.md
+++ b/docs/no-top-level-await.md
@@ -1,0 +1,31 @@
+# no-top-level-await
+
+This prevents the use of `await` at the top-level of documents (outside
+of an async function context)
+
+```js
+await asyncMethod();
+
+const results = await getAsyncResults();
+```
+
+These will not be allowed because they are not supported in the following browsers:
+
+ - Edge < 89
+ - Safari < 15
+ - Firefox < 89
+ - Chrome < 89
+
+
+## What is the Fix?
+
+You can wrap your `await` in an async Immediately Invoking Function
+Expression (IIFE).
+
+```js
+(async () => {
+    await asyncMethod();
+
+    const results = await getAsyncResults();
+})();
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -204,6 +204,12 @@ createRule(
   "disallow static blocks like `static { x = 1 }`",
   { ts: 2022 }
 );
+createRule(
+  "no-top-level-await",
+  "edge < 89, safari < 15, firefox < 89, chrome < 89",
+  "disallow await keyword outside of async function context",
+  { ts: 2022 }
+);
 
 // Proposals...
 createRule(

--- a/lib/rules/no-top-level-await.js
+++ b/lib/rules/no-top-level-await.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const functionTypes = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+]);
+
+module.exports = (context, badBrowser) => ({
+  AwaitExpression(node) {
+    let currentNode = node;
+    while (currentNode.parent) {
+      currentNode = currentNode.parent;
+      if (functionTypes.has(currentNode.type) && currentNode.async) {
+        return;
+      }
+    }
+    context.report(node, `Top-level await is not supported in ${badBrowser}`)
+  },
+})

--- a/test/no-top-level-await.js
+++ b/test/no-top-level-await.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const rule = require('../lib/index').rules['no-top-level-await']
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({languageOptions: {ecmaVersion: 2022}})
+
+ruleTester.run('no-top-level-await', rule, {
+  valid: [
+    {code: 'async function get () { return await asyncMethod(); }'},
+    {code: '(async () => { await getAsyncResults(); })();'},
+    {code: 'const get = async function get () { return await asyncMethod(); }'},
+    {code: 'const get = async () => { return await asyncMethod(); }'},
+  ],
+  invalid: [
+    {
+      code: 'await asyncMethod();',
+      errors: [
+        {
+          message: 'Top-level await is not supported in undefined'
+        }
+      ]
+    },
+    {
+      code: 'const results = await getAsyncResults();',
+      errors: [
+        {
+          message: 'Top-level await is not supported in undefined'
+        }
+      ]
+    },
+  ]
+})


### PR DESCRIPTION
feat: ES2022 `no-top-level-await`