### PR TITLE
No hashbang comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ for configuration. Here's some examples:
 - [no-dynamic-imports](./docs/no-dynamic-imports.md)
 - [no-edge-destructure-bug](./docs/no-edge-destructure-bug.md)
 - [no-exponentiation-operator](./docs/no-exponentiation-operator.md)
+- [no-hashbang-comment](./docs/no-hashbang-comment.md)
 - [no-logical-assignment-operator](./docs/no-logical-assignment-operator.md)
 - [no-nullish-coalescing](./docs/no-nullish-coalescing.md)
 - [no-numeric-separators](./docs/no-numeric-separators.md)

--- a/docs/no-hashbang-comment.md
+++ b/docs/no-hashbang-comment.md
@@ -1,0 +1,19 @@
+# no-hashbang-comment
+
+This prevents use of ES2023 hashang comments:
+
+```js
+#!/usr/bin/env node
+```
+
+These will not be allowed because they are not supported in the following browsers:
+
+ - Edge < 79
+ - Safari < 13.1
+ - Firefox < 67
+ - Chrome < 74
+
+
+## What is the Fix?
+
+You have to omit the comment.

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,6 +211,14 @@ createRule(
   { ts: 2022 }
 );
 
+// ES2023
+createRule(
+  "no-hashbang-comment",
+  "edge < 79, safari < 13.1, firefox < 67, chrome < 74",
+  "disallow hashbang comments",
+  { ts: 2022 }
+);
+
 // Proposals...
 createRule(
   "no-do-expression",
@@ -230,7 +238,7 @@ createRule(
 
 module.exports.configs.recommended = {
   plugins: ["escompat"],
-  parserOptions: { ecmaVersion: 2020 },
+  parserOptions: { ecmaVersion: 2023 },
   rules: Object.keys(module.exports.rules).reduce(
     (o, r) => ((o["escompat/" + r] = ["error"]), o),
     {}
@@ -242,7 +250,7 @@ module.exports.configs["flat/recommended"] = {
     escompat: module.exports
   },
   languageOptions: {
-    ecmaVersion: 2020
+    ecmaVersion: 2023
   },
   rules: Object.keys(module.exports.rules).reduce(
     (o, r) => ((o["escompat/" + r] = ["error"]), o),

--- a/lib/rules/no-hashbang-comment.js
+++ b/lib/rules/no-hashbang-comment.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = (context, badBrowser) => {
+  const { sourceCode = context.getSourceCode() } = context;
+  return {
+    'Program:exit' (node) {
+      const [comment] = sourceCode.getAllComments();
+      if (comment.type === 'Shebang') {
+        context.report(node, `Hashbang comments are not supported in ${badBrowser}`)
+      }
+    }
+  }
+}

--- a/test/check-rules.js
+++ b/test/check-rules.js
@@ -99,7 +99,7 @@ describe('documentation', () => {
       let consume = true
       const headings = contents.filter(line => {
         // Discard lines that aren't headers or thumbs
-        if (!(line.startsWith('#') || line.startsWith('\ud83d'))) return false
+        if (!(line.startsWith('#') || line.startsWith('\ud83d')) || line.startsWith('#!')) return false
         // Ignore all sub headings/thumbs between `### Options` and `## When Not To Use It`
         if (line === '### Options') {
           consume = false

--- a/test/no-hashbang-comment.js
+++ b/test/no-hashbang-comment.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const rule = require('../lib/index').rules['no-hashbang-comment']
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({languageOptions: {ecmaVersion: 2018}})
+
+ruleTester.run('no-hashbang-comment', rule, {
+  valid: [
+    {code: '// Regular comment'},
+    {code: '/* Regular comment */'},
+  ],
+  invalid: [
+    {
+      code: '#!/usr/bin/env node',
+      errors: [
+        {
+          message:
+            'Hashbang comments are not supported in undefined'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
Builds on #28

Closes #25.

feat: ES2023 `no-hashbang-comment`

(This is the last PR for now)