### PR TITLE
feat: add `no-regexp-v-flag` (and bump to ES2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ for configuration. Here's some examples:
 - [no-regexp-lookbehind](./docs/no-regexp-lookbehind.md)
 - [no-regexp-named-group](./docs/no-regexp-named-group.md)
 - [no-regexp-s-flag](./docs/no-regexp-s-flag.md)
+- [no-regexp-v-flag](./docs/no-regexp-v-flag.md)
 - [no-top-level-await](./docs/no-top-level-await.md)
 
 ## Inspiration

--- a/docs/no-regexp-s-flag.md
+++ b/docs/no-regexp-s-flag.md
@@ -21,17 +21,17 @@ These will not be allowed because they are not supported in the following browse
 The `s` flag is relatively simple sugar for `[\0-\uFFFF]`, so you can simply opt to write the un-sugared syntax:
 
 ```js
-let dotAll = `/./s`
+let dotAll = /./s
 
-let dotAll = `/[\0-\uFFFF]/`
+let dotAll = /[\0-\uFFFF]/
 ```
 
 If you are using it in combination with the `u` flag then you may adjust the pattern:
 
 ```js
-let dotAll = `/./su`
+let dotAll = /./su
 
-let dotAll = `/[\0-\u{10FFFF}]/`
+let dotAll = /[\0-\u{10FFFF}]/
 ```
 
 This can be safely disabled if you intend to compile code with the `@babel/plugin-transform-dotall-regex` Babel plugin, or `@babel/preset-env`.

--- a/docs/no-regexp-v-flag.md
+++ b/docs/no-regexp-v-flag.md
@@ -3,9 +3,9 @@
 This prevents the use of the `v` flag in RegExps
 
 ```js
-/abc/v
+/[\p{Letter}]/v
 
-new RegExp('abc', 'v')
+new RegExp('[\\p{Letter}]', 'v')
 ```
 
 These will not be allowed because they are not supported in the following browsers:

--- a/docs/no-regexp-v-flag.md
+++ b/docs/no-regexp-v-flag.md
@@ -1,0 +1,27 @@
+# no-regexp-v-flag
+
+This prevents the use of the `v` flag in RegExps
+
+```js
+/abc/v
+
+new RegExp('abc', 'v')
+```
+
+These will not be allowed because they are not supported in the following browsers:
+
+ - Edge > 0
+ - Safari < 17
+ - Firefox < 116
+ - Chrome < 112
+
+## What is the Fix?
+
+If you are not using the features required by the `v` flag (set
+notations and properties of string), you can use the `u` flag.
+
+```js
+let vFlag = /^[👍]$/u
+```
+
+This can be safely disabled if you intend to compile code with the `@babel/plugin-transform-unicode-sets-regex` Babel plugin, or `@babel/preset-env`.

--- a/docs/no-regexp-v-flag.md
+++ b/docs/no-regexp-v-flag.md
@@ -17,11 +17,11 @@ These will not be allowed because they are not supported in the following browse
 
 ## What is the Fix?
 
-If you are not using the features required by the `v` flag (set
-notations and properties of string), you can use the `u` flag.
+You can avoid using the `v` flag by expanding the sets to their unicode ranges:
 
 ```js
-let vFlag = /^[👍]$/u
+let vFlag = /[\p{ASCII}]/v;
+let noVFlag = /[\0-\x7F]/;
 ```
 
 This can be safely disabled if you intend to compile code with the `@babel/plugin-transform-unicode-sets-regex` Babel plugin, or `@babel/preset-env`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,7 +217,15 @@ createRule(
   "no-hashbang-comment",
   "edge < 79, safari < 13.1, firefox < 67, chrome < 74",
   "disallow hashbang comments",
-  { ts: 2022 }
+  { ts: 2023 }
+);
+
+// ES2024
+createRule(
+  "no-regexp-v-flag",
+  "edge > 0, safari < 17, firefox < 116, chrome < 112",
+  "disallow the use of the RegExp `v` flag",
+  { ts: 2024 }
 );
 
 // Proposals...
@@ -239,7 +247,7 @@ createRule(
 
 module.exports.configs.recommended = {
   plugins: ["escompat"],
-  parserOptions: { ecmaVersion: 2023 },
+  parserOptions: { ecmaVersion: 2024 },
   rules: Object.keys(module.exports.rules).reduce(
     (o, r) => ((o["escompat/" + r] = ["error"]), o),
     {}
@@ -252,7 +260,7 @@ module.exports.configs["flat/recommended"] = {
     escompat: module.exports
   },
   languageOptions: {
-    ecmaVersion: 2023
+    ecmaVersion: 2024
   },
   rules: Object.keys(module.exports.rules).reduce(
     (o, r) => ((o["escompat/" + r] = ["error"]), o),

--- a/lib/rules/no-regexp-v-flag.js
+++ b/lib/rules/no-regexp-v-flag.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = (context, badBrowser) => ({
+  'Literal[regex]'(node) {
+    if (node.regex.flags.includes('v')) {
+      context.report(node, `RegExp "v" flag is not supported in ${badBrowser}`)
+    }
+  },
+  'CallExpression[callee.name="RegExp"], NewExpression[callee.name="RegExp"]'(node) {
+    const [, flags] = node.arguments;
+    if (
+      flags &&
+      (
+        (
+          flags.type === 'Literal' &&
+          typeof flags.value === 'string' &&
+          flags.value.includes('v')
+        ) ||
+        (
+          flags.type === 'TemplateLiteral' &&
+          flags.quasis.some(({value: {raw}}) => raw.includes('v'))
+        )
+      )
+    ) {
+      context.report(node, `RegExp "v" flag is not supported in ${badBrowser}`)
+    }
+  }
+})

--- a/test/no-regexp-v-flag.js
+++ b/test/no-regexp-v-flag.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const rule = require('../lib/index').rules['no-regexp-v-flag']
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({languageOptions: {ecmaVersion: 2024}})
+
+ruleTester.run('no-regexp-v-flag', rule, {
+  valid: [
+    {code: '/foo.bar/'},
+    {code: '/foo.bar/g'},
+    {code: 'new RegExp("foo.bar")'},
+    {code: 'new RegExp("foo.bar", flags)'},
+    {code: 'new RegExp("foo.bar", "u")'},
+    {code: 'new RegExp("foo.bar", "g")'},
+    {code: 'RegExp("foo.bar", "g")'},
+  ],
+  invalid: [
+    {
+      code: '/foo.bar/v',
+      errors: [
+        {
+          message: 'RegExp "v" flag is not supported in undefined'
+        }
+      ]
+    },
+    {
+      code: 'new RegExp("foo.bar", "v")',
+      errors: [
+        {
+          message: 'RegExp "v" flag is not supported in undefined'
+        }
+      ]
+    },
+    {
+      code: 'new RegExp("foo.bar", `v`)',
+      errors: [
+        {
+          message: 'RegExp "v" flag is not supported in undefined'
+        }
+      ]
+    },
+    {
+      code: 'RegExp("foo.bar", "v")',
+      errors: [
+        {
+          message: 'RegExp "v" flag is not supported in undefined'
+        }
+      ]
+    },
+  ]
+})


### PR DESCRIPTION
feat: add `no-regexp-v-flag` (and bump to ES2024)

Also:
- fix: ensures no-hashbang-comment rule is in TS 2023
- docs: remove unneeded backticks in no-regexp-s-flag rule docs

Realized there was ES2024 and ES2025 too.