### PR TITLE
Fix breaking `this` while using Browserslist API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 const path = require("path");
 const browserslist = require("browserslist");
-const { findConfig } = require("browserslist/node");
+const browserslistNode = require("browserslist/node");
 const { version, homepage } = require("../package.json");
 const flatTypeScriptConfigs = {};
 const createRule = (name, browserstring, description, { ts = null } = {}) => {
@@ -25,7 +25,7 @@ const createRule = (name, browserstring, description, { ts = null } = {}) => {
     ),
     create(context) {
       let browsers = browserslist(browserstring);
-      const config = findConfig(path.dirname(
+      const config = browserslistNode.findConfig(path.dirname(
         context.filename ?? context.getFilename()
       )) || {
         defaults: "defaults",


### PR DESCRIPTION
Calling `{ key }` destroys `this` binding in Browserslist which lead to issues like https://github.com/browserslist/browserslist/issues/845

Note, that `browserslist/node` is private API, you should use just `browserslist.findConfig` (I will create a separated issue to discuss this changes).