### PR TITLE
no-regexp-lookbehind.js - fix negative lookbehind pattern

### DIFF
--- a/lib/rules/no-regexp-lookbehind.js
+++ b/lib/rules/no-regexp-lookbehind.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const hasLookbehind = s => s.includes('(?<=') || s.includes('(?<!)')
+const hasLookbehind = s => s.includes('(?<=') || s.includes('(?<!')
 
 module.exports = (context, badBrowser) => ({
   'Literal[regex]'(node) {


### PR DESCRIPTION
Removed the extra parenthesis.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion